### PR TITLE
Allow base queries

### DIFF
--- a/test/integration/query_test.exs
+++ b/test/integration/query_test.exs
@@ -5,11 +5,12 @@ defmodule Integration.Query.Test do
 
   test "simple request" do
     person = insert(:person)
+
     result =
       Dummy.Person
-      |> QueryEx.from_schema
-      |> QueryEx.build
-      |> Dummy.Repo.one
+      |> QueryEx.from_query()
+      |> QueryEx.build()
+      |> Dummy.Repo.one()
       |> elem(0)
 
     assert result.id == person.id
@@ -21,10 +22,10 @@ defmodule Integration.Query.Test do
 
     result =
       Dummy.Person
-      |> QueryEx.from_schema
+      |> QueryEx.from_query()
       |> QueryEx.filter("email", :=, person.email)
-      |> QueryEx.build
-      |> Dummy.Repo.one
+      |> QueryEx.build()
+      |> Dummy.Repo.one()
       |> elem(0)
 
     assert result.id == person.id
@@ -36,10 +37,10 @@ defmodule Integration.Query.Test do
 
     result =
       Dummy.Person
-      |> QueryEx.from_schema
+      |> QueryEx.from_query()
       |> QueryEx.filter("organization.name", :=, "Test")
-      |> QueryEx.build
-      |> Dummy.Repo.one
+      |> QueryEx.build()
+      |> Dummy.Repo.one()
       |> elem(0)
 
     assert result.id == person.id
@@ -51,18 +52,26 @@ defmodule Integration.Query.Test do
     person2 = insert(:person, email: "b", organization: organization)
     insert(:person)
 
+    # Setup a base query that filters by organization name
+    query =
+      from(
+        p in Dummy.Person,
+        join: o in Dummy.Organization,
+        where: o.id == p.organization_id,
+        where: o.name == ^organization.name
+      )
+
     result =
-      Dummy.Person
-      |> QueryEx.from_schema
-      |> QueryEx.filter("organization.name", :=, organization.name)
+      query
+      |> QueryEx.from_query()
       |> QueryEx.order_by("email", :desc)
       |> QueryEx.order_by("organization.name", :asc)
       |> QueryEx.side_load("organization")
-      |> QueryEx.build
-      |> Dummy.Repo.all
+      |> QueryEx.build()
+      |> Dummy.Repo.all()
       |> Enum.map(&elem(&1, 0))
 
-    assert [person2.id, person1.id] == Enum.map(result, &(&1.id))
-    assert [organization.name, organization.name] == Enum.map(result, &(&1.organization.name))
+    assert [person2.id, person1.id] == Enum.map(result, & &1.id)
+    assert [organization.name, organization.name] == Enum.map(result, & &1.organization.name)
   end
 end

--- a/test/query_engine_test.exs
+++ b/test/query_engine_test.exs
@@ -7,8 +7,9 @@ defmodule QueryExTest do
   alias QueryEx.Query.Order
 
   describe "build" do
-    test "set the schema" do
-      assert %Request{schema: Dummy.Person} == QueryEx.from_schema(Dummy.Person)
+    test "set the query" do
+      assert %Request{query: Ecto.Queryable.to_query(Dummy.Person)} ==
+               QueryEx.from_query(Dummy.Person)
     end
   end
 
@@ -16,24 +17,25 @@ defmodule QueryExTest do
     test "set a single filter" do
       request =
         Dummy.Person
-        |> QueryEx.from_schema
+        |> QueryEx.from_query()
         |> QueryEx.filter("table.column", :=, "test")
 
-      assert %Request{filters: [%Filter{field: "table.column", operator: :=, value: "test"}]} = request
+      assert %Request{filters: [%Filter{field: "table.column", operator: :=, value: "test"}]} =
+               request
     end
 
     test "set multiple filters" do
       filters =
         Dummy.Person
-        |> QueryEx.from_schema
+        |> QueryEx.from_query()
         |> QueryEx.filter("table.column", :=, "test")
         |> QueryEx.filter("column", :like, "test%")
         |> Map.get(:filters)
 
       assert [
-        %Filter{field: "column", operator: :like, value: "test%"},
-        %Filter{field: "table.column", operator: :=, value: "test"}
-      ] = filters
+               %Filter{field: "column", operator: :like, value: "test%"},
+               %Filter{field: "table.column", operator: :=, value: "test"}
+             ] = filters
     end
   end
 
@@ -41,7 +43,7 @@ defmodule QueryExTest do
     test "set sort" do
       sorts =
         Dummy.Person
-        |> QueryEx.from_schema
+        |> QueryEx.from_query()
         |> QueryEx.order_by("table.column", :asc)
         |> Map.get(:sorts)
 
@@ -51,12 +53,15 @@ defmodule QueryExTest do
     test "set multiple sorts" do
       sorts =
         Dummy.Person
-        |> QueryEx.from_schema
+        |> QueryEx.from_query()
         |> QueryEx.order_by("table.column", :asc)
         |> QueryEx.order_by("column", :desc)
         |> Map.get(:sorts)
 
-      assert [%Order{field: "column", direction: :desc}, %Order{field: "table.column", direction: :asc}] == sorts
+      assert [
+               %Order{field: "column", direction: :desc},
+               %Order{field: "table.column", direction: :asc}
+             ] == sorts
     end
   end
 
@@ -64,7 +69,7 @@ defmodule QueryExTest do
     test "set side load" do
       side_loads =
         Dummy.Person
-        |> QueryEx.from_schema
+        |> QueryEx.from_query()
         |> QueryEx.side_load("table")
         |> Map.get(:side_loads)
 
@@ -74,7 +79,7 @@ defmodule QueryExTest do
     test "set multiple sorts" do
       side_loads =
         Dummy.Person
-        |> QueryEx.from_schema
+        |> QueryEx.from_query()
         |> QueryEx.side_load("table1")
         |> QueryEx.side_load("table2")
         |> Map.get(:side_loads)
@@ -87,7 +92,7 @@ defmodule QueryExTest do
     test "set limit and offset" do
       request =
         Dummy.Person
-        |> QueryEx.from_schema
+        |> QueryEx.from_query()
         |> QueryEx.page(10, 20)
 
       assert %Request{limit: 10, offset: 20} = request
@@ -96,7 +101,7 @@ defmodule QueryExTest do
     test "set multiple sorts" do
       side_loads =
         Dummy.Person
-        |> QueryEx.from_schema
+        |> QueryEx.from_query()
         |> QueryEx.side_load("table1")
         |> QueryEx.side_load("table2")
         |> Map.get(:side_loads)

--- a/test/query_ex/engine/filterer_test.exs
+++ b/test/query_ex/engine/filterer_test.exs
@@ -27,7 +27,7 @@ defmodule QueryEx.Engine.FiltererTest do
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.email == person.email
     end
@@ -36,19 +36,21 @@ defmodule QueryEx.Engine.FiltererTest do
       person = insert(:person, organization: nil)
 
       filter = %Filter{field: organization_field, operator: :=, value: nil}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.id == person.id
 
       # Negative test
       filter = %Filter{field: email_field, operator: :=, value: nil}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query == nil
     end
@@ -59,21 +61,21 @@ defmodule QueryEx.Engine.FiltererTest do
 
       associations =
         "organization"
-        |> Association.from_path
-        |> Association.assign_bindings
+        |> Association.from_path()
+        |> Association.assign_bindings(0)
 
       field =
         "organization.name"
-        |> Field.from_path
+        |> Field.from_path()
         |> Field.set_association(associations)
-      
+
       filter = %Filter{field: field, operator: :=, value: organization.name}
 
       query =
         Dummy.Person
         |> Joiner.join(Enum.at(associations, 0))
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.email == person.email
     end
@@ -83,19 +85,21 @@ defmodule QueryEx.Engine.FiltererTest do
 
       # Positive test
       filter = %Filter{field: field, operator: :!=, value: person.email <> "1"}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.id == person.id
 
       # Negative test
       filter = %Filter{field: field, operator: :!=, value: person.email}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query == nil
     end
@@ -105,19 +109,21 @@ defmodule QueryEx.Engine.FiltererTest do
 
       # Positive test
       filter = %Filter{field: field, operator: :!=, value: nil}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.id == person.id
 
       # Negative test
       filter = %Filter{field: organization_field, operator: :!=, value: nil}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query == nil
     end
@@ -127,41 +133,45 @@ defmodule QueryEx.Engine.FiltererTest do
 
       # Positive test
       filter = %Filter{field: field, operator: :>, value: person.id - 1}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.id == person.id
 
       # Negative test
       filter = %Filter{field: field, operator: :>, value: person.id}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query == nil
     end
-    
+
     test "with <", %{id_field: field} do
       person = insert(:person)
 
       # Positive test
       filter = %Filter{field: field, operator: :<, value: person.id + 1}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.id == person.id
 
       # Negative test
       filter = %Filter{field: field, operator: :<, value: person.id}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query == nil
     end
@@ -171,19 +181,21 @@ defmodule QueryEx.Engine.FiltererTest do
 
       # Positive test
       filter = %Filter{field: field, operator: :like, value: "like%"}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.id == person.id
 
       # Negative test
       filter = %Filter{field: field, operator: :like, value: "notlike%"}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query == nil
     end
@@ -193,64 +205,69 @@ defmodule QueryEx.Engine.FiltererTest do
 
       # Positive test
       filter = %Filter{field: field, operator: :not_like, value: "notlike%"}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.id == person.id
 
       # Negative test
       filter = %Filter{field: field, operator: :not_like, value: "like%"}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query == nil
     end
 
-    
     test "with >=", %{id_field: field} do
       person = insert(:person)
 
       # Positive test
       filter = %Filter{field: field, operator: :>=, value: person.id - 1}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.id == person.id
 
       # Negative test
       filter = %Filter{field: field, operator: :>=, value: person.id + 1}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query == nil
     end
-    
+
     test "with <=", %{id_field: field} do
       person = insert(:person)
 
       # Positive test
       filter = %Filter{field: field, operator: :<=, value: person.id + 1}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query.id == person.id
 
       # Negative test
       filter = %Filter{field: field, operator: :<=, value: person.id - 1}
+
       query =
         Dummy.Person
         |> Filterer.filter(filter)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query == nil
     end

--- a/test/query_ex/engine/joiner_test.exs
+++ b/test/query_ex/engine/joiner_test.exs
@@ -13,14 +13,14 @@ defmodule QueryEx.Engine.JoinerTest do
 
       associations =
         "organization"
-        |> Association.from_path
-        |> Association.assign_bindings
+        |> Association.from_path()
+        |> Association.assign_bindings(0)
 
       query_person =
         Dummy.Person
         |> Joiner.join(List.first(associations))
         |> where([_, o], o.name == ^organization.name)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query_person.id == person.id
     end
@@ -32,18 +32,17 @@ defmodule QueryEx.Engine.JoinerTest do
 
       associations =
         "organization.country"
-        |> Association.from_path
-        |> Association.assign_bindings
+        |> Association.from_path()
+        |> Association.assign_bindings(0)
 
       query_person =
         Dummy.Person
         |> Joiner.join(Enum.at(associations, 0))
         |> Joiner.join(Enum.at(associations, 1))
         |> where([_, _, c], c.name == ^country.name)
-        |> Dummy.Repo.one
+        |> Dummy.Repo.one()
 
       assert query_person.id == person.id
     end
   end
 end
-

--- a/test/query_ex/engine/orderer_test.exs
+++ b/test/query_ex/engine/orderer_test.exs
@@ -26,12 +26,12 @@ defmodule QueryEx.Engine.OrdererTest do
       query =
         Dummy.Person
         |> Orderer.order(order)
-        |> Dummy.Repo.all
-        |> Enum.map(&(&1.email))
+        |> Dummy.Repo.all()
+        |> Enum.map(& &1.email)
 
       assert query == ["A", "B"]
     end
-    
+
     test "with descending order", %{email_field: field} do
       insert(:person, email: "A")
       insert(:person, email: "B")
@@ -40,8 +40,8 @@ defmodule QueryEx.Engine.OrdererTest do
       query =
         Dummy.Person
         |> Orderer.order(order)
-        |> Dummy.Repo.all
-        |> Enum.map(&(&1.email))
+        |> Dummy.Repo.all()
+        |> Enum.map(& &1.email)
 
       assert query == ["B", "A"]
     end
@@ -55,26 +55,24 @@ defmodule QueryEx.Engine.OrdererTest do
 
       associations =
         "organization"
-        |> Association.from_path
-        |> Association.assign_bindings
+        |> Association.from_path()
+        |> Association.assign_bindings(0)
 
       field =
         "organization.name"
-        |> Field.from_path
+        |> Field.from_path()
         |> Field.set_association(associations)
-      
+
       order = %Order{field: field, direction: :asc}
 
       query =
         Dummy.Person
         |> Joiner.join(Enum.at(associations, 0))
         |> Orderer.order(order)
-        |> Repo.all
-        |> Enum.map(&(&1.id))
+        |> Repo.all()
+        |> Enum.map(& &1.id)
 
       assert query == [person.id, person2.id]
     end
   end
 end
-
-

--- a/test/query_ex/query/association_test.exs
+++ b/test/query_ex/query/association_test.exs
@@ -1,7 +1,7 @@
 defmodule QueryEx.Query.AssociationTest do
   use ExUnit.Case, async: true
   doctest QueryEx.Query.Association
-  
+
   alias QueryEx.Query.Association
 
   describe "from_path" do
@@ -45,7 +45,7 @@ defmodule QueryEx.Query.AssociationTest do
     test "with single association" do
       associations = [%Association{path: "test"}]
 
-      [with_binding] = Association.assign_bindings(associations)
+      [with_binding] = Association.assign_bindings(associations, 0)
 
       assert with_binding.binding == 1
     end
@@ -53,16 +53,16 @@ defmodule QueryEx.Query.AssociationTest do
     test "with multiple associations" do
       associations = [%Association{path: "test"}, %Association{path: "test2"}]
 
-      [with_binding1, with_binding2] = Association.assign_bindings(associations)
+      [with_binding1, with_binding2] = Association.assign_bindings(associations, 0)
 
       assert with_binding1.binding == 1
       assert with_binding2.binding == 2
     end
-    
+
     test "with duplicate path associations" do
       associations = [%Association{path: "test"}, %Association{path: "test"}]
 
-      [with_binding] = Association.assign_bindings(associations)
+      [with_binding] = Association.assign_bindings(associations, 0)
 
       assert with_binding.binding == 1
     end
@@ -72,11 +72,11 @@ defmodule QueryEx.Query.AssociationTest do
     test "with standard list" do
       associations =
         "a.b"
-        |> Association.from_path
-        |> Association.assign_bindings
+        |> Association.from_path()
+        |> Association.assign_bindings(0)
 
-      assert Enum.at(associations, 0).binding == 1 
-      assert Enum.at(associations, 0).parent_binding == 0 
+      assert Enum.at(associations, 0).binding == 1
+      assert Enum.at(associations, 0).parent_binding == 0
 
       assert Enum.at(associations, 1).binding == 2
       assert Enum.at(associations, 1).parent_binding == 1
@@ -95,19 +95,27 @@ defmodule QueryEx.Query.AssociationTest do
     test "duplicates" do
       assert Association.from_side_loads(["organization", "organization"]) == [:organization]
     end
-    
+
     test "overlapping side loads" do
-      assert Association.from_side_loads(["organization.country", "organization"]) == [{:organization, :country}]
-      assert Association.from_side_loads(["organization", "organization.country"]) == [{:organization, :country}]
+      assert Association.from_side_loads(["organization.country", "organization"]) == [
+               {:organization, :country}
+             ]
+
+      assert Association.from_side_loads(["organization", "organization.country"]) == [
+               {:organization, :country}
+             ]
     end
 
     test "non overlapping side loads" do
-      assert Association.from_side_loads(["organization.country", "person"]) == [{:organization, :country}, :person]
+      assert Association.from_side_loads(["organization.country", "person"]) == [
+               {:organization, :country},
+               :person
+             ]
     end
 
     test "long side loads" do
-      assert Association.from_side_loads(["table1.table2.table3.table4.table5", "table1.table6"]) == 
-        [{:table1, [{:table2, [table3: [table4: :table5]]}, :table6]}]
+      assert Association.from_side_loads(["table1.table2.table3.table4.table5", "table1.table6"]) ==
+               [{:table1, [{:table2, [table3: [table4: :table5]]}, :table6]}]
     end
   end
 end


### PR DESCRIPTION
Instead of forcing an ecto schema to be the base query for the API, allow an ecto query to be passed in and expanded upon.