### PR TITLE
Fix warning by removing double quotes from test alias in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule QueryEx.Mixfile do
   end
 
   defp aliases do
-    ["test": ["ecto.create --quiet", "ecto.migrate", "test"]]
+    [test: ["ecto.create --quiet", "ecto.migrate", "test"]]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/dummy", "test/support"]


### PR DESCRIPTION
This commit fixes the following warning by remove double quotes
from the test alias in the mix.exs file.

warning: found quoted keyword "test" but the quotes are not
required. Note that keywords are always atoms, even when
quoted, and quotes should only be used to introduce keywords
with foreign characters in them
  /Users/dj.jain/src/hapi/deps/queryex/mix.exs:49